### PR TITLE
Some fixes & chgs to generate candle compliant wsx from legacy ocx/exe

### DIFF
--- a/ATLHarvester/UtilFinalizeHarvesterMutator64.cs
+++ b/ATLHarvester/UtilFinalizeHarvesterMutator64.cs
@@ -530,7 +530,7 @@ namespace ATLCOMHarvester
                             {
                                 if (null == registryValue.Name)
                                 {
-                                    wixClass.Description = registryValue.Value;
+                                    if (registryValue.Value.Length > 0) wixClass.Description = registryValue.Value;
                                     processed = true;
                                 }
                                 else if (String.Equals(registryValue.Name, "AppID", StringComparison.OrdinalIgnoreCase))

--- a/ATLHarvester/UtilFinalizeHarvesterMutator64.cs
+++ b/ATLHarvester/UtilFinalizeHarvesterMutator64.cs
@@ -876,7 +876,12 @@ namespace ATLCOMHarvester
                                     }
                                     else if (String.Equals(parts[3], "helpdir", StringComparison.OrdinalIgnoreCase))
                                     {
-                                        if (registryValue.Value.StartsWith("[", StringComparison.Ordinal) && (registryValue.Value.EndsWith("]", StringComparison.Ordinal)
+                                        string dirPrefix = null; // I did not find how to retrieve this from the FileHarvester
+                                        if (this.directories.Count > 0) dirPrefix = ((Wix.Directory)this.directories[0]).Id.Substring(0, 3); // A workaround is to steal the prefix from the first known directory
+
+                                        if (dirPrefix != null
+                                            && ( registryValue.Value.StartsWith(string.Concat("[#", dirPrefix), StringComparison.Ordinal) || registryValue.Value.StartsWith(string.Concat("[!", dirPrefix), StringComparison.Ordinal))
+                                            && (registryValue.Value.EndsWith("]", StringComparison.Ordinal)
                                             || registryValue.Value.EndsWith("]\\", StringComparison.Ordinal)))
                                         {
                                             typeLib.HelpDirectory = registryValue.Value.Substring(1, registryValue.Value.LastIndexOf(']') - 1);

--- a/ATLHarvester/UtilFinalizeHarvesterMutator64.cs
+++ b/ATLHarvester/UtilFinalizeHarvesterMutator64.cs
@@ -913,10 +913,14 @@ namespace ATLCOMHarvester
                                 {
                                     typeLib.Language = Convert.ToInt32(parts[3], CultureInfo.InvariantCulture);
 
-                                    if ((registryValue.Value.StartsWith("[!", StringComparison.Ordinal) || registryValue.Value.StartsWith("[#", StringComparison.Ordinal))
-                                        && registryValue.Value.EndsWith("]", StringComparison.Ordinal))
+                                    if ((registryValue.Value.StartsWith("[!", StringComparison.Ordinal) || registryValue.Value.StartsWith("[#", StringComparison.Ordinal)))
                                     {
-                                        parentIndex = String.Concat("file/", registryValue.Value.Substring(2, registryValue.Value.Length - 3));
+                                        string[] win32 = registryValue.Value.Split('\\');
+                                        if (win32[0].EndsWith("]", StringComparison.Ordinal))
+                                        {
+                                            parentIndex = String.Concat("file/", win32[0].Substring(2, win32[0].Length - 3));
+                                            if (win32.Length == 2) typeLib.ResourceId = Convert.ToInt32(win32[1], CultureInfo.InvariantCulture);
+                                        }
                                     }
 
                                     processed = true;

--- a/RegRedir/RegRedir.vcxproj
+++ b/RegRedir/RegRedir.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -18,7 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-  <Import Project="$(SolutionDir)targets.xml"/>
+  <Import Project="$(SolutionDir)targets.xml" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D3850773-2402-411B-818F-C26D01233191}</ProjectGuid>
     <RootNamespace>RegRedir</RootNamespace>
@@ -29,23 +29,23 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
I needed to make few changes to the ATLHaversterExtension so that it could support our legacy ocx/exe files.

The 3 requirements was 
- support options -ag, -srd, -dr and -var
- support empty class description to avoid **error CNDL0006**
- support multiple typelibs in same file to avoid **error CNDL0014** and **error CNDL0047**

NOTE:  **error CNDL0047** was reported years ago here: https://sourceforge.net/p/wix/bugs/2758/
Then duplicated by: https://github.com/wixtoolset/issues/issues/3412/. It did not seem to be addressed yet.

